### PR TITLE
Fix for category check

### DIFF
--- a/src/Knife.php
+++ b/src/Knife.php
@@ -38,7 +38,7 @@ class Knife {
                 $post->name = $value['value'];
             } 
             if($value['name'] == '{}category') {
-                if($value['domain'] == 'category') {
+                if($value['attributes']['domain'] == 'category') {
                     $post->categories[] = $value['value'];
                 } else {
                     $post->tags[] = $value['value'];


### PR DESCRIPTION
since data structure looks like this:

```
array(3) {
  ["name"]=>
  string(10) "{}category"
  ["value"]=>
  string(15) "Foo bar"
  ["attributes"]=>
  array(2) {
    ["domain"]=>
    string(8) "category"
    ["nicename"]=>
    string(15) "foo-bar"
  }
}
```

you were checking on the wrong level and categories were imported into tags. After this small change, everything is imported as expected.
